### PR TITLE
Handling only MissingTranslation with 3.2.1 dosn't work. 

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -29,7 +29,7 @@ If there are any missing translations then it will print out a YAML snippet for 
 
 h3. Usage in development environment
 
-The following hooks up the I18n::MissingTranslations middleware in development mode. You might want to add these lines as an initializer:
+The following hooks up the I18n::MissingTranslations middleware in development mode. You might want to add these lines as an initializer or add it to your application.rb:
 
 <pre>
 require 'i18n/missing_translations'

--- a/lib/i18n/missing_translations/handler.rb
+++ b/lib/i18n/missing_translations/handler.rb
@@ -2,7 +2,7 @@ module I18n
   class MissingTranslations
     module Handler
       def call(exception, locale, key, options)
-        I18n.missing_translations.log(exception.keys) if MissingTranslation === exception
+        I18n.missing_translations.log(exception.keys) if [MissingTranslation, MissingTranslationData].include? exception
         super
       end
     end


### PR DESCRIPTION
Had some problems getting i18n-missing_translations to work and figured out it had to do with the handling of Exceptions. MissingTranslation alone logs no missing translation with Rails 3.2.1, I18n 0.6.0. Match for MissingTranslation and MissingTranslationData solves the problem, at least for me and my mates. 
